### PR TITLE
Add related project to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@ It only needs the first 12 bytes.
 ## Related
 
 - [file-type](https://github.com/sindresorhus/file-type) - Detect the file type of a Buffer/Uint8Array
+- [is-webp-extended](https://github.com/mooyoul/is-webp-extended) - Extended version of is-webp package which supports Animated WebP
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ It only needs the first 12 bytes.
 ## Related
 
 - [file-type](https://github.com/sindresorhus/file-type) - Detect the file type of a Buffer/Uint8Array
-- [is-webp-extended](https://github.com/mooyoul/is-webp-extended) - Extended version of is-webp package which supports Animated WebP
+- [is-webp-extended](https://github.com/mooyoul/is-webp-extended) - Extended version of this package which supports checking for animated WebP
 
 
 ## License


### PR DESCRIPTION
I made extended version of this package, which added support of Animated WebP detection.
Since WebP Container is based on RIFF, and requires seeking to read animation related bitstream.

i thought adopting animation webp detection feature will break your simple code (that's the reason why i love your packages also haha), and it's hard to support "isomorphic package" (e.g. Node Stream, Browser blob...)
i decided to make new my own version of `is-webp`  instead of breaking your simple code. and i made it! ;) 
(also there is another related package for Node environment - [node-webpinfo](https://github.com/mooyoul/node-webpinfo) - check it out!)